### PR TITLE
Fix crashes with invalid chords

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
-    "chord-magic": "^1.0.0",
+    "chord-magic": "^2.1.1",
     "lodash": "^4.13.1",
     "mustache": "^2.2.1"
   }

--- a/src/lib/chords.js
+++ b/src/lib/chords.js
@@ -119,17 +119,20 @@ function findKey(chords) {
     // Return the most likely (most frequent) key for the chords passed in.
     return _.maxBy(_.map(keys, function (val, key) {
         return {key: key, count: val};
-    }), 'count').key;
+    }), 'count').key || '';
 }
 
 function Chord(chordText, transposeProperties) {
     this.transposeProperties = transposeProperties;
-    this.chordMagicked = chordMagic.parse(chordText);
+    if (chordText.match(/\w+/)) this.chordMagicked = chordMagic.parse(chordText);
+    else this.text = chordText;
 }
 
 Chord.prototype.getText = function () {
     var chord = this.chordMagicked;
     var transpose = this.transposeProperties.transpose;
+
+    if (!chord) return this.text;
 
     if (this.transposeProperties.targetKey !== null) {
         // Work out transpose from original key
@@ -153,7 +156,9 @@ Chord.prototype.getText = function () {
 };
 
 Chord.prototype.getOrigText = function () {
-    return chordMagic.prettyPrint(this.chordMagicked);
+    if (this.chordMagicked)
+        return chordMagic.prettyPrint(this.chordMagicked);
+    else return this.text;
 };
 
 function Chords() {
@@ -187,11 +192,14 @@ Chords.prototype.setTranspose = function (transpose) {
 
 Chords.prototype.createChord = function (chordText) {
     var chord = new Chord(chordText, this.transposeProperties);
+
     this.chords.push(chord);
-    // Detect key
-    this.transposeProperties.origKey = findKey(this.chords.map(function (chord) {
-        return chord.getOrigText();
-    }));
+    if (chord.chordMagicked) {
+        // Detect key
+        this.transposeProperties.origKey = findKey(this.chords.map(function (chord) {
+            return chord.getOrigText();
+        }));
+    }
     return chord;
 };
 

--- a/src/lib/chords.js
+++ b/src/lib/chords.js
@@ -24,13 +24,13 @@ var intervals = [
 function getSharpEquivalent(chordText) {
     return chordText.split("/").map(function (val) {
         if (val.indexOf('b') === 1) {
-          var idx = notes.indexOf(val.substring(0, 2)) - 1;
+            var idx = notes.indexOf(val.substring(0, 2)) - 1;
 
-          if (idx < 0) {
-              idx = notes.length - 1;
-          }
+            if (idx < 0) {
+                idx = notes.length - 1;
+            }
 
-          return notes[idx] + '#' + val.substring(2);
+            return notes[idx] + '#' + val.substring(2);
         }
 
         return val;


### PR DESCRIPTION
Currently, this library will crash if an invalid chord, such as `[:||]`, is attempted to be parsed.
This pull request addresses that issue by adding some fail-safes and returning the text of the chord if it is unable to be parsed by chordmagic.